### PR TITLE
Makes permissions less broad & Firefox Add-ons URL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ This is a Chrome/Firefox/Opera extension that circumvents BoilerKey. The code is
 6. Navigate to the [Blackboard login page](https://mycourses.purdue.edu), and follow the instructions in the dialogs.
 
 ### Firefox Installation Instructions
+
+#### Install from Firefox Add-ons
+https://addons.mozilla.org/en-US/firefox/addon/boilerkey-helper/
+
+#### Install from Source
 1. Clone the extension.
 2. Navigate to about:debugging in Mozilla Firefox.
 3. Click "Load Temporary Add-on".

--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,6 @@
     "default_icon": "icons/icon128.png"
   },
   "permissions": [
-    "<all_urls>"
+    "https://api-1b9bef70.duosecurity.com/"
   ]
 }


### PR DESCRIPTION
The Chrome Developer Dashboard is correct in saying that our permissions were too broad.  This change limits it to the scope of Duo, which is all we need for the POST.

It also adds the URL to Firefox Add-ons page.  It will now be a lot easier for users of Firefox to quickly install the extension.  