### PR TITLE
Fixed error when the activation link contains leading spaces; Fixed e…

### DIFF
--- a/content.js
+++ b/content.js
@@ -145,8 +145,7 @@ async function askForInfo() {
         location.reload();
     } catch (e) {
         // Catch error and print the error message
-        error = JSON.parse(e["response"]);
-        confirm("Activation failed, please try again. A new BoilerKey will need to be created. Error: " + error["message"]);
+        confirm("Activation failed, please try again. A new BoilerKey will need to be created. Error: " + e["response"]);
         location.reload();
     }
 }


### PR DESCRIPTION
# Description

Fixed 2 issues with the extension.

Issue1: No prompt/error messages is displayed when a user enters an invalid activation token/URL.
Issue2: Activation Token/URL with leading ' ' will be identified as invalid. 
 
## Changes

- [ ] Add a try-catch clause for the XHR HTTP request that catches the rejected promise.
- [ ] Trim the link entered by the user

# How Has This Been Tested?

Have a clean environment that has been "reset", or open a private/incognito window. 

- [ ] Go to https://www.purdue.edu/apps/account/cas/login, in the prompted message box, enter a random activation token with length of 20, like "aaaaaaaaaaaaaaaaaaaa". There should be an alert showing that the activation code entered is invalid, with the error message from the server. 
- [ ] Go to https://www.purdue.edu/apps/account/cas/login, in the prompted message box, enter "          https://m-1b9bef70.duosecurity.com/activate/XXXXXXXXXXXXXXXXXXXX" or "     aaaaaaaaaaaaaaaaaaaa"(both with leading spaces), the extension should go ahead and process the entered information, and return the validation result of the activation token.

**Test Configuration**:
Browser: Firefox Quantum 66.0.2 (64-bit)
OS: Linux Mint 19 tara
Kernel: x86_64 Linux 4.15.0-47-generic