### PR TITLE
Fix HOTP code generation for counter values > 127

### DIFF
--- a/content.js
+++ b/content.js
@@ -146,7 +146,7 @@ if (window.location.href.startsWith("https://www.purdue.edu/apps/account/cas/log
             localStorage.removeItem("pin");
             localStorage.removeItem("code");
             localStorage.removeItem("username");
-            localStorage.removeItem("count");
+            localStorage.removeItem("counter");
             localStorage.removeItem("hotpSecret");
             //Get the user's info to setup a new BoilerKey
             askForInfo();
@@ -156,7 +156,7 @@ if (window.location.href.startsWith("https://www.purdue.edu/apps/account/cas/log
         localStorage.removeItem("pin");
         localStorage.removeItem("code");
         localStorage.removeItem("username");
-        localStorage.removeItem("count");
+        localStorage.removeItem("counter");
         localStorage.removeItem("hotpSecret");
         //Get the user's info to setup a new BoilerKey
         askForInfo();

--- a/jsOTP.js
+++ b/jsOTP.js
@@ -94,10 +94,11 @@
       }
   
       getOtp(key, counter) {
-        var digest, h, offset, shaObj, v;
-        shaObj = new jsSHA("SHA-1", "TEXT");
+        var digest, h, offset, shaObj, v, counterString;
+        shaObj = new jsSHA("SHA-1", "HEX");
         shaObj.setHMACKey(key, "TEXT");
-        shaObj.update(this.uintToString(new Uint8Array(this.intToBytes(counter))));
+        counterString = ("0000000000000000" + counter.toString(16)).slice(-16); // padded hex counter value
+        shaObj.update(counterString);
         digest = shaObj.getHMAC("HEX");
         // Get byte array
         h = this.hexToBytes(digest);


### PR DESCRIPTION
Closes #16 

This was actually already fixed in a pull request in the JS-OTP repo: https://github.com/jiangts/JS-OTP/pull/5
I tested various values from 0 to 99999999 and it resolves the issues I had.